### PR TITLE
Deposit QSR command for pillars and sentinels

### DIFF
--- a/src/ZenonCli/Options/Pillar.cs
+++ b/src/ZenonCli/Options/Pillar.cs
@@ -51,7 +51,14 @@ namespace ZenonCli.Options
         {
         }
 
-        [Verb("pillar.withdrawQsr", HelpText = "")]
+        [Verb("pillar.depositQsr", HelpText = "Deposit QSR to the pillar contract")]
+        public class DepositQsr : KeyStoreAndConnectionOptions
+        {
+            [Value(0, Required = true, MetaName = "amount")]
+            public long Amount { get; set; }
+        }
+
+        [Verb("pillar.withdrawQsr", HelpText = "Withdraw deposited QSR from the pillar contract")]
         public class WithdrawQsr : KeyStoreAndConnectionOptions
         {
         }

--- a/src/ZenonCli/Options/Sentinel.cs
+++ b/src/ZenonCli/Options/Sentinel.cs
@@ -24,7 +24,14 @@ namespace ZenonCli.Options
         {
         }
 
-        [Verb("sentinel.withdrawQsr", HelpText = "")]
+        [Verb("sentinel.depositQsr", HelpText = "Deposit QSR to the sentinel contract")]
+        public class DepositQsr : KeyStoreAndConnectionOptions
+        {
+            [Value(0, Required = true, MetaName = "amount")]
+            public long Amount { get; set; }
+        }
+
+        [Verb("sentinel.withdrawQsr", HelpText = "Withdraw deposited QSR from the sentinel contract")]
         public class WithdrawQsr : KeyStoreAndConnectionOptions
         {
         }

--- a/src/ZenonCli/Program.cs
+++ b/src/ZenonCli/Program.cs
@@ -836,40 +836,31 @@ namespace ZenonCli
 
         static async Task ProcessAsync(Sentinel.DepositQsr options)
         {
-            long amount = 0;
             var tokenStandard = TokenStandard.QsrZts;
+
             var address = Znn.Instance.DefaultKeyPair.Address;
 
-            var info = await Znn.Instance.Ledger
+            var account = await Znn.Instance.Ledger
                 .GetAccountInfoByAddress(address);
 
-            bool ok = true;
-            bool found = false;
+            var balance = account.BalanceInfoList
+                .FirstOrDefault(x => x.Token.TokenStandard == tokenStandard);
 
-            foreach (var item in info.BalanceInfoList)
-            {
-                if (item.Token.TokenStandard == tokenStandard)
-                {
-                    amount = options.Amount * item.Token.DecimalsExponent;
-
-                    if (item.Balance < amount)
-                    {
-                        WriteError($"You only have {FormatAmount(item.Balance.Value, item.Token.Decimals)} {item.Token.Symbol} tokens");
-                        ok = false;
-                        break;
-                    }
-                    found = true;
-                }
-            }
-
-            if (!ok) return;
-            if (!found)
+            if (balance == null)
             {
                 WriteError($"You only have {FormatAmount(0, 0)} {tokenStandard} tokens");
                 return;
             }
 
-            WriteInfo($"Depositing {FormatAmount(amount, Constants.QsrDecimals)} QSR ...");
+            var amount = options.Amount * balance.Token.DecimalsExponent;
+
+            if (balance.Balance < amount)
+            {
+                WriteError($"You only have {FormatAmount(balance.Balance.Value, balance.Token.Decimals)} {balance.Token.Symbol} tokens");
+                return;
+            }
+
+            WriteInfo($"Depositing {FormatAmount(amount, balance.Token.Decimals)} {balance.Token.Symbol} ...");
 
             await Znn.Instance.Send(Znn.Instance.Embedded.Sentinel.DepositQsr(amount));
 
@@ -1162,40 +1153,31 @@ namespace ZenonCli
 
         static async Task ProcessAsync(Pillar.DepositQsr options)
         {
-            long amount = 0;
             var tokenStandard = TokenStandard.QsrZts;
+
             var address = Znn.Instance.DefaultKeyPair.Address;
 
-            var info = await Znn.Instance.Ledger
+            var account = await Znn.Instance.Ledger
                 .GetAccountInfoByAddress(address);
 
-            bool ok = true;
-            bool found = false;
+            var balance = account.BalanceInfoList
+                .FirstOrDefault(x => x.Token.TokenStandard == tokenStandard);
 
-            foreach (var item in info.BalanceInfoList)
-            {
-                if (item.Token.TokenStandard == tokenStandard)
-                {
-                    amount = options.Amount * item.Token.DecimalsExponent;
-
-                    if (item.Balance < amount)
-                    {
-                        WriteError($"You only have {FormatAmount(item.Balance.Value, item.Token.Decimals)} {item.Token.Symbol} tokens");
-                        ok = false;
-                        break;
-                    }
-                    found = true;
-                }
-            }
-
-            if (!ok) return;
-            if (!found)
+            if (balance == null)
             {
                 WriteError($"You only have {FormatAmount(0, 0)} {tokenStandard} tokens");
                 return;
             }
 
-            WriteInfo($"Depositing {FormatAmount(amount, Constants.QsrDecimals)} QSR ...");
+            var amount  = options.Amount * balance.Token.DecimalsExponent;
+
+            if (balance.Balance < amount)
+            {
+                WriteError($"You only have {FormatAmount(balance.Balance.Value, balance.Token.Decimals)} {balance.Token.Symbol} tokens");
+                return;
+            }
+
+            WriteInfo($"Depositing {FormatAmount(amount, balance.Token.Decimals)} {balance.Token.Symbol} ...");
 
             await Znn.Instance.Send(Znn.Instance.Embedded.Pillar.DepositQsr(amount));
 

--- a/src/ZenonCli/Program.cs
+++ b/src/ZenonCli/Program.cs
@@ -837,8 +837,13 @@ namespace ZenonCli
         static async Task ProcessAsync(Sentinel.DepositQsr options)
         {
             var tokenStandard = TokenStandard.QsrZts;
-
             var address = Znn.Instance.DefaultKeyPair.Address;
+
+            if (options.Amount <= 0)
+            {
+                WriteError($"The amount must be positive");
+                return;
+            }
 
             var account = await Znn.Instance.Ledger
                 .GetAccountInfoByAddress(address);
@@ -1154,8 +1159,13 @@ namespace ZenonCli
         static async Task ProcessAsync(Pillar.DepositQsr options)
         {
             var tokenStandard = TokenStandard.QsrZts;
-
             var address = Znn.Instance.DefaultKeyPair.Address;
+
+            if (options.Amount <= 0)
+            {
+                WriteError($"The amount must be positive");
+                return;
+            }
 
             var account = await Znn.Instance.Ledger
                 .GetAccountInfoByAddress(address);


### PR DESCRIPTION
This PR adds the `pillar.depositQsr` and `sentinel.depositQsr` commands for pillars and sentries.

This enhancement makes it possible to register pillars and sentinels with the CLI.

There are no restrictions on the amount to be deposited. The amount deposited can withdrawn with the `pillar.withdrawQsr` and `sentinel.withdrawQsr` commands.