### PR TITLE
Update Zenon SDK to version 0.6.4

### DIFF
--- a/src/ZenonCli/Commands/Bridge.Admin.cs
+++ b/src/ZenonCli/Commands/Bridge.Admin.cs
@@ -136,8 +136,8 @@ namespace ZenonCli.Commands
                     WriteInfo("Setting token pair ...");
 
                     var setTokenPair = ZnnClient.Embedded.Bridge.SetTokenPair(
-                        NetworkClass!.Value,
-                        ChainId!.Value,
+                        (uint)NetworkClass!.Value,
+                        (uint)ChainId!.Value,
                         tokenStandard,
                         TokenAddress,
                         Bridgeable!.Value,
@@ -145,7 +145,7 @@ namespace ZenonCli.Commands
                         Owned!.Value,
                         minAmount,
                         feePercentage,
-                        RedeemDelay!.Value,
+                        (ulong)RedeemDelay!.Value,
                         Metadata);
                     await ZnnClient.Send(setTokenPair);
 
@@ -177,7 +177,7 @@ namespace ZenonCli.Commands
                     WriteInfo("Removing token pair ...");
 
                     var removeTokenPair = ZnnClient.Embedded.Bridge
-                        .RemoveTokenPair(NetworkClass!.Value, ChainId!.Value, tokenStandard, TokenAddress);
+                        .RemoveTokenPair((uint)NetworkClass!.Value, (uint)ChainId!.Value, tokenStandard, TokenAddress);
                     await ZnnClient.Send(removeTokenPair);
 
                     WriteInfo("Done");
@@ -191,7 +191,7 @@ namespace ZenonCli.Commands
                 public string? TransactionHash { get; set; }
 
                 [Value(1, MetaName = "logIndex", Required = true, HelpText = "The log index in the block of the transaction that locked/burned the funds")]
-                public int? LogIndex { get; set; }
+                public long? LogIndex { get; set; }
 
                 protected override async Task ProcessAsync()
                 {
@@ -202,7 +202,7 @@ namespace ZenonCli.Commands
                     WriteInfo("Revoking unwrap request ...");
 
                     var revokeUnwrapRequest =
-                        ZnnClient.Embedded.Bridge.RevokeUnwrapRequest(transactionHash, LogIndex!.Value);
+                        ZnnClient.Embedded.Bridge.RevokeUnwrapRequest(transactionHash, (uint)LogIndex!.Value);
                     await ZnnClient.Send(revokeUnwrapRequest);
 
                     WriteInfo("Done");
@@ -362,10 +362,10 @@ namespace ZenonCli.Commands
                     await AssertBridgeAdminAsync();
 
                     WriteInfo("Setting orchestrator information...");
-                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.SetOrchestratorInfo(WindowSize!.Value,
-                        KeyGenThreshold!.Value,
-                        ConfirmationsToFinality!.Value,
-                        EstimatedMomentumTime!.Value));
+                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.SetOrchestratorInfo((ulong)WindowSize!.Value,
+                        (uint)KeyGenThreshold!.Value,
+                        (uint)ConfirmationsToFinality!.Value,
+                        (uint)EstimatedMomentumTime!.Value));
                     WriteInfo("Done");
                 }
             }
@@ -425,7 +425,7 @@ namespace ZenonCli.Commands
 
                     WriteInfo("Setting bridge network...");
                     await ZnnClient.Send(ZnnClient.Embedded.Bridge.SetNetwork(
-                        networkClass, chainId, name, contractAddress, Metadata));
+                        (uint)networkClass, (uint)chainId, name, contractAddress, Metadata));
                     WriteInfo("Done");
                 }
             }
@@ -460,7 +460,7 @@ namespace ZenonCli.Commands
 
 
                     WriteInfo("Removing bridge network...");
-                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.RemoveNetwork(networkClass, chainId));
+                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.RemoveNetwork((uint)networkClass, (uint)chainId));
                     WriteInfo("Done");
                 }
             }
@@ -499,7 +499,7 @@ namespace ZenonCli.Commands
                     JsonConvert.DeserializeObject(Metadata!);
 
                     WriteInfo("Setting bridge network metadata...");
-                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.SetNetworkMetadata(networkClass, chainId, Metadata!));
+                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.SetNetworkMetadata((uint)networkClass, (uint)chainId, Metadata!));
                     WriteInfo("Done");
                 }
             }
@@ -515,7 +515,7 @@ namespace ZenonCli.Commands
                     await AssertBridgeAdminAsync();
 
                     WriteInfo("Setting bridge redeem delay...");
-                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.SetRedeemDelay(RedeemDelay!.Value));
+                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.SetRedeemDelay((ulong)RedeemDelay!.Value));
                     WriteInfo("Done");
                 }
             }

--- a/src/ZenonCli/Commands/Bridge.Network.cs
+++ b/src/ZenonCli/Commands/Bridge.Network.cs
@@ -44,8 +44,8 @@ namespace ZenonCli.Commands
                     }
 
                     var network = await ZnnClient.Embedded.Bridge.GetNetworkInfo(
-                        this.NetworkClass!.Value,
-                        this.ChainId!.Value);
+                        (uint)this.NetworkClass!.Value,
+                        (uint)this.ChainId!.Value);
 
                     if (network.NetworkClass == 0 || network.ChainId == 0)
                     {

--- a/src/ZenonCli/Commands/Bridge.Unwrap.cs
+++ b/src/ZenonCli/Commands/Bridge.Unwrap.cs
@@ -14,7 +14,7 @@ namespace ZenonCli.Commands
                 public string? Hash { get; set; }
 
                 [Value(1, MetaName = "logIndex", Required = true, HelpText = "The log index")]
-                public int? LogIndex { get; set; }
+                public long? LogIndex { get; set; }
 
                 protected override async Task ProcessAsync()
                 {
@@ -22,7 +22,7 @@ namespace ZenonCli.Commands
                     var transactionHash = ParseHash(Hash);
 
                     var request = await ZnnClient.Embedded.Bridge
-                        .GetUnwrapTokenRequestByHashAndLog(transactionHash, LogIndex!.Value);
+                        .GetUnwrapTokenRequestByHashAndLog(transactionHash, (uint)LogIndex!.Value);
 
                     if (request.Redeemed == 0 && request.Revoked == 0)
                     {
@@ -190,14 +190,14 @@ namespace ZenonCli.Commands
                 public string? Hash { get; set; }
 
                 [Value(1, MetaName = "logIndex", Required = true, HelpText = "The log index")]
-                public int? LogIndex { get; set; }
+                public long? LogIndex { get; set; }
 
                 protected override async Task ProcessAsync()
                 {
                     var transactionHash = ParseHash(Hash);
 
                     var request = await ZnnClient.Embedded.Bridge
-                        .GetUnwrapTokenRequestByHashAndLog(transactionHash, LogIndex!.Value);
+                        .GetUnwrapTokenRequestByHashAndLog(transactionHash, (uint)LogIndex!.Value);
 
                     await WriteAsync(request);
                 }

--- a/src/ZenonCli/Commands/Bridge.Wrap.cs
+++ b/src/ZenonCli/Commands/Bridge.Wrap.cs
@@ -41,7 +41,7 @@ namespace ZenonCli.Commands
                     await AssertBalanceAsync(address, tokenStandard, amount);
 
                     var info =
-                        await ZnnClient.Embedded.Bridge.GetNetworkInfo(this.NetworkClass!.Value, this.ChainId!.Value);
+                        await ZnnClient.Embedded.Bridge.GetNetworkInfo((uint)this.NetworkClass!.Value, (uint)this.ChainId!.Value);
 
                     if (info.NetworkClass == 0 || info.ChainId == 0)
                     {
@@ -65,7 +65,7 @@ namespace ZenonCli.Commands
 
                     WriteInfo("Wrapping token ...");
                     var wrapToken = ZnnClient.Embedded.Bridge
-                        .WrapToken(NetworkClass!.Value, ChainId!.Value, ToAddress, amount, tokenStandard);
+                        .WrapToken((uint)NetworkClass!.Value, (uint)ChainId!.Value, ToAddress, amount, tokenStandard);
                     await ZnnClient.Send(wrapToken);
                     WriteInfo("Done");
                 }
@@ -110,7 +110,7 @@ namespace ZenonCli.Commands
                     {
                         list = await ZnnClient.Embedded.Bridge
                             .GetAllWrapTokenRequestsByToAddressNetworkClassAndChainId(
-                                Address, NetworkClass!.Value, ChainId!.Value);
+                                Address, (uint)NetworkClass!.Value, (uint)ChainId!.Value);
                     }
                     else
                     {

--- a/src/ZenonCli/Commands/CommandBase.cs
+++ b/src/ZenonCli/Commands/CommandBase.cs
@@ -126,7 +126,7 @@ namespace ZenonCli.Commands
             {
                 if (!String.Equals(options.Chain, "auto", StringComparison.OrdinalIgnoreCase))
                 {
-                    ZnnClient.ChainIdentifier = int.Parse(options.Chain);
+                    ZnnClient.ChainIdentifier = ulong.Parse(options.Chain);
                 }
                 else
                 {

--- a/src/ZenonCli/Commands/Htlc.cs
+++ b/src/ZenonCli/Commands/Htlc.cs
@@ -137,7 +137,7 @@ namespace ZenonCli.Commands
 
                 long expirationTime = this.ExpirationTime * 60 * 60; // convert to seconds
                 Momentum currentFrontierMomentum = await ZnnClient.Ledger.GetFrontierMomentum();
-                long currentTime = currentFrontierMomentum.Timestamp;
+                long currentTime = (long)currentFrontierMomentum.Timestamp;
                 expirationTime += currentTime;
 
                 if (this.HashLock != null)

--- a/src/ZenonCli/Commands/Orchestrator.cs
+++ b/src/ZenonCli/Commands/Orchestrator.cs
@@ -116,7 +116,7 @@ namespace ZenonCli.Commands
             public string? TransactionHash { get; set; }
 
             [Value(3, MetaName = "logIndex", Required = true, HelpText = "The log index in the block of the transaction that locked/burned the funds on the source network; together with txHash it creates a unique identifier for a transaction")]
-            public int? LogIndex { get; set; }
+            public long? LogIndex { get; set; }
 
             [Value(4, MetaName = "address", Required = true, HelpText = "The destination NoM address")]
             public string? Address { get; set; }

--- a/src/ZenonCli/Commands/Plasma.cs
+++ b/src/ZenonCli/Commands/Plasma.cs
@@ -27,7 +27,7 @@ namespace ZenonCli.Commands
 
                 var address = ZnnClient.DefaultKeyPair.Address;
                 var fusionEntryList = await ZnnClient.Embedded.Plasma.GetEntriesByAddress(address,
-                        this.PageIndex.Value, this.PageSize.Value);
+                        (uint)this.PageIndex.Value, (uint)this.PageSize.Value);
 
                 if (fusionEntryList.Count > 0)
                 {
@@ -131,7 +131,7 @@ namespace ZenonCli.Commands
                     }
                     pageIndex++;
                     fusions = await ZnnClient.Embedded.Plasma
-                        .GetEntriesByAddress(address, pageIndex: pageIndex);
+                        .GetEntriesByAddress(address, (uint)pageIndex);
                 }
 
                 if (!found)

--- a/src/ZenonCli/Commands/Spork.cs
+++ b/src/ZenonCli/Commands/Spork.cs
@@ -25,7 +25,7 @@ namespace ZenonCli.Commands
                 AssertPageRange(PageIndex.Value, PageSize.Value);
 
                 var result = await ZnnClient.Embedded.Spork
-                    .GetAll(PageIndex.Value, PageSize.Value);
+                    .GetAll((uint)PageIndex.Value, (uint)PageSize.Value);
 
                 if (result == null || result.Count == 0)
                 {

--- a/src/ZenonCli/Commands/Stake.cs
+++ b/src/ZenonCli/Commands/Stake.cs
@@ -29,7 +29,7 @@ namespace ZenonCli.Commands
                 AssertPageRange(PageIndex.Value, PageSize.Value);
 
                 var stakeList = await ZnnClient.Embedded.Stake.GetEntriesByAddress(
-                    address, PageIndex.Value, PageSize.Value);
+                    address, (uint)PageIndex.Value, (uint)PageSize.Value);
 
                 if (stakeList.Count > 0)
                 {
@@ -117,7 +117,7 @@ namespace ZenonCli.Commands
                 bool one = false;
                 bool gotError = false;
 
-                var entries = await ZnnClient.Embedded.Stake.GetEntriesByAddress(address, pageIndex);
+                var entries = await ZnnClient.Embedded.Stake.GetEntriesByAddress(address, (uint)pageIndex);
 
                 while (entries.List.Length != 0)
                 {
@@ -134,7 +134,7 @@ namespace ZenonCli.Commands
                         }
                     }
                     pageIndex++;
-                    entries = await ZnnClient.Embedded.Stake.GetEntriesByAddress(address, pageIndex);
+                    entries = await ZnnClient.Embedded.Stake.GetEntriesByAddress(address, (uint)pageIndex);
                 }
 
                 if (gotError)

--- a/src/ZenonCli/Commands/Stats.cs
+++ b/src/ZenonCli/Commands/Stats.cs
@@ -22,7 +22,7 @@ namespace ZenonCli.Commands
                 WriteInfo($"numGoroutine: {osInfo.numGoroutine}");
             }
 
-            private string FormatMemory(long size)
+            private string FormatMemory(ulong size)
             {
                 var sizeUnits = new string[] { "B", "kB", "MB", "GB", "TB" };
 

--- a/src/ZenonCli/Commands/Token.cs
+++ b/src/ZenonCli/Commands/Token.cs
@@ -26,7 +26,7 @@ namespace ZenonCli.Commands
 
                 AssertPageRange(PageIndex.Value, PageSize.Value);
 
-                var tokenList = await ZnnClient.Embedded.Token.GetAll(PageIndex.Value, PageSize.Value);
+                var tokenList = await ZnnClient.Embedded.Token.GetAll((uint)PageIndex.Value, (uint)PageSize.Value);
 
                 foreach (var token in tokenList.List)
                 {

--- a/src/ZenonCli/ZenonCli.csproj
+++ b/src/ZenonCli/ZenonCli.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Cryptography.ECDSA.Secp256k1" Version="1.1.3" />
-    <PackageReference Include="Zenon.Sdk" Version="0.6.1" />
+    <PackageReference Include="Zenon.Sdk" Version="0.6.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This update prevents the overflow error messages as discussed in https://github.com/hypercore-one/znn_sdk_csharp/pull/11.