### PR TITLE
Update Zenon SDK to version 0.6.6

### DIFF
--- a/src/ZenonCli/Commands/Bridge.Admin.cs
+++ b/src/ZenonCli/Commands/Bridge.Admin.cs
@@ -31,8 +31,7 @@ namespace ZenonCli.Commands
                     await AssertBridgeAdminAsync();
 
                     WriteInfo("Halting the bridge ...");
-                    // Use signature value '1' to circumvent the empty string unpack issue.
-                    await ZnnClient.Send(ZnnClient.Embedded.Bridge.Halt("1"));
+                    await ZnnClient!.Send(ZnnClient!.Embedded.Bridge.Halt(""));
                     WriteInfo("Done");
                 }
             }

--- a/src/ZenonCli/Commands/CommandBase.cs
+++ b/src/ZenonCli/Commands/CommandBase.cs
@@ -171,7 +171,7 @@ namespace ZenonCli.Commands
         {
             try
             {
-                return AmountUtils.ExtractDecimals(double.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture), (int)decimals);
+                return AmountUtils.ExtractDecimals(value, (int)decimals);
             }
             catch (Exception e)
             {

--- a/src/ZenonCli/Commands/Orchestrator.cs
+++ b/src/ZenonCli/Commands/Orchestrator.cs
@@ -59,8 +59,7 @@ namespace ZenonCli.Commands
                     WriteInfo("Changing public key...");
                 }
 
-                // Use signature value '1' to circumvent the empty string unpack issue.
-                await ZnnClient.Send(ZnnClient.Embedded.Bridge.ChangeTssECDSAPubKey(this.PubKey, "1", "1"));
+                await ZnnClient!.Send(ZnnClient!.Embedded.Bridge.ChangeTssECDSAPubKey(this.PubKey, "", ""));
                 WriteInfo("Done");
             }
         }
@@ -78,11 +77,8 @@ namespace ZenonCli.Commands
                     await AssertBridgeAdminAsync();
                 }
 
-                // Use signature value '1' to circumvent the empty string unpack issue.
-                var signature = Signature ?? "1";
-
                 WriteInfo("Halting bridge operations ...");
-                await ZnnClient.Send(ZnnClient.Embedded.Bridge.Halt(signature));
+                await ZnnClient!.Send(ZnnClient!.Embedded.Bridge.Halt(Signature));
                 WriteInfo("Done");
             }
         }

--- a/src/ZenonCli/ZenonCli.csproj
+++ b/src/ZenonCli/ZenonCli.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Cryptography.ECDSA.Secp256k1" Version="1.1.3" />
-    <PackageReference Include="Zenon.Sdk" Version="0.6.4" />
+    <PackageReference Include="Zenon.Sdk" Version="0.6.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This update removes the empty string circumventions as discussed in https://github.com/hypercore-one/znn_sdk_csharp/issues/13.