### PR TITLE
Update Zenon Ledger Wallet to 0.1.2

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
 			<PrivateAssets>all</PrivateAssets>
-			<Version>3.5.103</Version>
+			<Version>3.6.133</Version>
 		</PackageReference>
 	</ItemGroup>
 </Project>

--- a/src/ZenonCli/ZenonCli.csproj
+++ b/src/ZenonCli/ZenonCli.csproj
@@ -28,9 +28,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Cryptography.ECDSA.Secp256k1" Version="1.1.3" />
-    <PackageReference Include="HidApi.Net" Version="1.0.0" />
+    <PackageReference Include="HidApi.Net" Version="1.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Zenon.Wallet.Ledger" Version="0.1.1" />
+    <PackageReference Include="Zenon.Wallet.Ledger" Version="0.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates the following dependencies:

- Zenon Ledger Wallet to 0.1.2 
- HidApi.Net to 1.0.2.
- NerdBank.GitVersioning 3.6.133