### PR TITLE
Update Zenon Ledger Wallet to 0.1.3

### DIFF
--- a/src/ZenonCli/ZenonCli.csproj
+++ b/src/ZenonCli/ZenonCli.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Cryptography.ECDSA.Secp256k1" Version="1.1.3" />
     <PackageReference Include="HidApi.Net" Version="1.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Zenon.Wallet.Ledger" Version="0.1.2" />
+    <PackageReference Include="Zenon.Wallet.Ledger" Version="0.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates the following dependencies:

- Zenon Ledger Wallet to 0.1.3
- Uses the updated subscription method